### PR TITLE
Combine batch size and boxes node into single output node for PP_DocLayoutV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ python ov_infer.py \
     --threshold 0.5
 ```
 
+#### Combine batch size and boxes node for PP-DocLayoutV2
+In PP-DocLayoutV2, its output includes two nodes, one is batch size and the other one is output boxes.
+
+* Output Nodes:
+  ```bash
+  Output 0: fetch_name_0, shape: [?,8], type: <Type: 'float32'>
+  Output 1: fetch_name_1, shape: [?], type: <Type: 'int32_t'>
+  ```
+
+To handle output easily, you can use `combine_bs_and_boxes_node.py` to combine batch size and boxes node as single output nodes and model will be saved as `<model_name>_combined.xml`.
+
+* Usage
+  ```bash
+  python combine_bs_and_boxes_node.py \
+      --model_path pp_doclayoutv2.xml \
+  ```
+
+
+* Output Nodes after combine batch size and boxes node:
+  ```bash
+  Output 0: Concat.254, shape: [?,300,8], type: <Type: 'float32'>
+  ```
+
+
 ## 📖 Parameters
 
 | Parameter | Type | Required | Default | Description |

--- a/combine_bs_and_boxes_node.py
+++ b/combine_bs_and_boxes_node.py
@@ -1,0 +1,64 @@
+import argparse
+
+import openvino as ov
+
+from pathlib import Path
+
+from openvino.runtime.passes import Manager, MatcherPass, WrapType, Matcher
+from openvino.runtime import opset11 as ops
+
+class combine_bs_and_boxes_node(MatcherPass):
+    def __init__(self, transpose_node_list, ov_model):
+        MatcherPass.__init__(self)
+        self.model_changed = False
+        self.ov_model = ov_model
+
+        param = WrapType("opset11.Concat")
+
+        def callback(matcher: Matcher) -> bool:
+            root = matcher.get_match_root()
+            if root is None:
+                return False
+            root_output = matcher.get_match_value()
+            for y in transpose_node_list:
+                root_name = root.get_friendly_name()
+                if root_name.find(y) != -1 :
+                    new_result = ops.result(root_output, name=f'{root_name}' + '/sink_port_0')
+                    self.ov_model.add_results([new_result])
+                    self.model_changed = True
+                    transpose_node_list.remove(y)
+
+            return True
+
+        self.register_matcher(Matcher(param,"combine_bs_and_boxes_node"), callback)
+
+def main():
+    parser = argparse.ArgumentParser(description="Combine batch size and boxes nodes for pp_doclayoutv2 model")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        required=True,
+        help="OpenVINO IR directory (.xml 文件)"
+    )
+    
+    args = parser.parse_args()
+    core = ov.Core()
+
+    layer_before_reshape_names = [
+        "Concat.253"
+    ]
+
+    model_path = Path(args.model_path)
+    ov_model = core.read_model(args.model_path)
+    original_results = ov_model.get_results()
+
+    manager = Manager()
+    manager.register_pass(combine_bs_and_boxes_node(layer_before_reshape_names, ov_model))
+    manager.run_passes(ov_model)
+    for _result in original_results:
+        ov_model.remove_result(_result)
+
+    ov.save_model(ov_model, "{}_rm.xml".format(model_path.stem))
+
+if __name__ == "__main__":
+    main()

--- a/combine_bs_and_boxes_node.py
+++ b/combine_bs_and_boxes_node.py
@@ -58,7 +58,7 @@ def main():
     for _result in original_results:
         ov_model.remove_result(_result)
 
-    ov.save_model(ov_model, "{}_rm.xml".format(model_path.stem))
+    ov.save_model(ov_model, "{}_combined.xml".format(model_path.stem))
 
 if __name__ == "__main__":
     main()

--- a/ov_infer.py
+++ b/ov_infer.py
@@ -872,6 +872,9 @@ def paddle_ov_doclayout(model_path, image_path, output_dir, device="GPU", thresh
         )
     else:
         # Fallback to DETR-style postprocess (older models)
+        if output[0].ndim == 3:
+            output[0] = np.squeeze(output[0], axis = 0)
+
         results = postprocess_detections_detr(
             output, scale_h, scale_w, orig_h, orig_w,
             threshold=threshold,
@@ -952,4 +955,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
In PP-DocLayoutV2, its output includes two nodes, one is batch size and the other one is output boxes.

* Output Nodes:
  ```bash
  Output 0: fetch_name_0, shape: [?,8], type: <Type: 'float32'>
  Output 1: fetch_name_1, shape: [?], type: <Type: 'int32_t'>
  ```

To handle output easily, I use `combine_bs_and_boxes_node.py` to combine batch size and boxes node as single output nodes and model will be saved as `<model_name>_combined.xml`.

* Output Nodes after combine batch size and boxes node:
  ```bash
  Output 0: Concat.254, shape: [?,300,8], type: <Type: 'float32'>
  ```